### PR TITLE
vagrant up 커맨드 오류로 인한 Vagrantfile 수정

### DIFF
--- a/vagrant-kubernetes/Vagrantfile
+++ b/vagrant-kubernetes/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
       v.vm.network :private_network,ip: spec[:private_ip]
       #v.vm.network :public_network,ip:  spec[:public_ip], bridge: bridge_if
       v.vm.provider "virtualbox" do |vbox|
-        vbox.gui = false
+        vbox.gui = true
         vbox.cpus = spec[:cpu]
         vbox.memory = spec[:memory]
         i = 1


### PR DESCRIPTION
안녕하세요. 아래 환경으로 학습 환경 2 구축 중에 에러가 발생했습니다.
- macOS(Intel Chip) Monterey Version 12.4
- Vagrant 2.3.1
- VirtualBox Version 6.1.26 r145957

```
There was on error while executing VBoxManage, a CLI used by Vagrant for controlling VirtualBox. The command and stderr is shown below Command: ["hostonlyif", "create"]

Stderr: 0%... Progress state: NS_ERROR_FAILURE VBoxManage: error: Failed to create the host-only adapter VBoxManage: error: VBoxNetAdpCtl: Error while adding new interface: failed to open /dev/vboxnetctl: No such file or directory

VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component HostNetworkInterface, interface IHostNetworkInterface VBoxManage: error: Context: "int handleCreate(HandlerArg*, int, int*)" at line 68 of file VBoxManageHostonly.cpp
```

위 에러 메세지로 구글링하면 아주 다양한 해결책이 나오는데요, 그 중 거의 유일한 해결책이 Vagrantfile의 `vbox.gui` 옵션을 `true`로 바꾸는 것이었습니다. (VM, Vagrant 재설치, 다른 버전으로 설치, 여러가지 커맨드 실행, 권한 허용 등의 방법이 소용이 없었습니다.)

vm, 도커와 k8s 환경에 익숙하지 않아 이 부분이 어떤 이유로 문제를 해결했는지 알 수 없지만 저와 같은 현상이었던 사람이 꽤 많은 것 같아 PR을 올립니다.
제가 바꾼 옵션이 특정 환경에서만 적용되는 것이라면 따로 리드미에 언급만 해도 좋을 것 같습니다.